### PR TITLE
Fix TypeScript typing of bigints

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,7 @@ declare const fnv1a: {
 	//=> 13487074350300261116944693128525960095n
 	```
 	*/
-	bigInt(string: string, options?: fnv1a.Options): BigInt;
+	bigInt(string: string, options?: fnv1a.Options): bigint;
 };
 
 export = fnv1a;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -2,4 +2,4 @@ import {expectType} from 'tsd';
 import fnv1a = require('.');
 
 expectType<number>(fnv1a('🦄🌈'));
-expectType<BigInt>(fnv1a.bigInt('🦄🌈', {size: 128}));
+expectType<bigint>(fnv1a.bigInt('🦄🌈', {size: 128}));


### PR DESCRIPTION
The typescript typehints were incorrect. They were refering to the `BigInt` class instead of the `bigint` type. This made typescript trip in this situation:

```typescript
const foo = 1n;
const bar = foo - fnv1a.bigInt('foobar');
```

In this case, typescript compiler would complain that the minus operator does not work with `bigint` and `BigInt`. Workaround without this patch:

```typescript
const bar = foo - (fnv1a.bigInt('foobar') as bigint);
```